### PR TITLE
NOVA-29052 Nova Logging -  default timestring and updated default colors for alternative level names

### DIFF
--- a/ByteParser/ByteParserLegacy.cs
+++ b/ByteParser/ByteParserLegacy.cs
@@ -17,10 +17,15 @@
 
 namespace SmartLogReader
 {
+    using System;
+
     public class ByteParserLegacy : ByteParser
     {
         private static readonly string LegacyKey1 = "TrimbleNo";
         private static readonly string LegacyKey2 = "novaSuite";
+
+        private static readonly DateTime FixedFallbackDateTime = new DateTime(2025, 7, 1, 12, 0, 0, DateTimeKind.Local);
+        private static readonly string FixedFallbackTimeString = FixedFallbackDateTime.ToUniversalTime().ToStringN();
 
         public ByteParserLegacy(byte[] bytes)
         {
@@ -59,6 +64,9 @@ namespace SmartLogReader
             token = GetNext();
             token = GetNext();
             record.Class = GetNext().TrimEnd(new char[] { ':' });
+
+            // fallback to have always a TimeString, because it seems to be mandatory for versions > version 2.3.1.
+            record.TimeString = FixedFallbackTimeString;
 
             record.Message = GetNextLine();
             record.Method = " ";

--- a/Utilities/Record.cs
+++ b/Utilities/Record.cs
@@ -414,9 +414,12 @@ namespace SmartLogReader
             {
                 newSpec("Debug", 1),
                 newSpec("Information", 0),
+                newSpec("Info", 0),
                 newSpec("Warning", 3),
+                newSpec("Warn", 3),
                 newSpec("Error", 2),
                 newSpec("Fatal", 11),
+                newSpec("Critical", 11),
                 newSpec("None", 6)
             };
 


### PR DESCRIPTION
Hello Wolfgang,
I have a small PR for SmartLogReader  version 2.6.0, that supports viewing of simple legacy Nova logs, as in version 2.3.1
The problem in 2.6.0 is, that log-entries without any timestring are no longer shown.

Kind regards
Didi

NOVA-29052 Nova-Logging (48)- SmartLogReader ByteParserLegacy - add a default FixedFallbackTimeString , so that it will always be defined.
NOVA-29052 Nova-Logging (49)- SmartLogReader GetDefaultColorSpecs - support default colors for alternative level names ("Info", "Warn", "Critical")
NOVA-29052 Nova-Logging (50)- SmartLogReader App - Title  add "[dma12345-patched]" to show that updated version is in use.